### PR TITLE
getUsersForGroup fix infinite loop

### DIFF
--- a/lib/components/getUsersForGroup.js
+++ b/lib/components/getUsersForGroup.js
@@ -41,6 +41,9 @@ function GroupUsersFinder (opts, groupName, callback) {
   this.chunks = []
   this.chunksProcessed = 0
   this.users = new Map()
+  if (!this.opts.hasOwnProperty('recursionstack')) {
+    this.opts.recursionstack = []
+  }
 }
 
 /**
@@ -63,11 +66,17 @@ GroupUsersFinder.prototype.forEachIter = function forEachIter (member, acb) {
   }
 
   // We have a group, so we recursively get the users in it
-  ad.getUsersForGroup(this.opts, member.cn, (err, nestedUsers) => {
-    if (err) throw err
-    nestedUsers.forEach(u => this.users.set(u.dn, u))
+  // but escape if group is already in the stack, which happens when group A is member of group B and group B is member of group A
+  if (this.opts.recursionstack.indexOf(member.dn) === -1) {
+    // prefer to use member.dn instead member.cn, because cn may not be unique
+    ad.getUsersForGroup(this.opts, member.dn, (err, nestedUsers) => {
+      if (err) throw err
+      nestedUsers.forEach(u => this.users.set(u.dn, u))
+      acb()
+    })
+  } else {
     acb()
-  })
+  }
 }
 
 /**
@@ -143,6 +152,7 @@ GroupUsersFinder.prototype.find = function find () {
       return this.callback(null, group)
     }
 
+    this.opts.recursionstack.push(group.dn)
     if (!Array.isArray(group.member)) {
       group.member = (group.member) ? [group.member] : []
     }


### PR DESCRIPTION
Fix for issue that getUsersForGroup crashes if group is member of itself (https://github.com/jsumners/node-activedirectory/issues/58).
Also: call getUsersForGroup with member.dn instead member.cn, because customer has multiple groups with identical cn.